### PR TITLE
Fix modal detail card opening position

### DIFF
--- a/src/components/ui/dialog-override.css
+++ b/src/components/ui/dialog-override.css
@@ -1,10 +1,10 @@
-/* Dialog/Modal Override Styles */
+/* Dialog/Modal Override Styles - Simplified and Fixed */
 
 /* Ensure Radix UI portal is properly positioned */
 [data-radix-portal] {
   position: fixed !important;
   inset: 0 !important;
-  z-index: 99999 !important;
+  z-index: 50 !important;
   pointer-events: none;
   display: flex !important;
   align-items: center !important;
@@ -19,83 +19,41 @@
 [data-radix-dialog-overlay] {
   position: fixed !important;
   inset: 0 !important;
-  z-index: 99998 !important;
+  z-index: 49 !important;
 }
 
-/* Content positioning - force center */
+/* Content positioning - simplified centering */
 [data-radix-dialog-content] {
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
   transform: translate(-50%, -50%) !important;
-  z-index: 99999 !important;
-  max-height: 85vh !important;
-  max-width: min(900px, 90vw) !important;
-  margin: 0 !important;
-  display: flex !important;
-  flex-direction: column !important;
-}
-
-/* Prevent transform conflicts */
-@media screen and (max-width: 768px) {
-  [data-radix-dialog-content] {
-    width: calc(100vw - 2rem) !important;
-    max-width: calc(100vw - 2rem) !important;
-  }
-}
-
-/* Handle different zoom levels */
-@media screen and (min-zoom: 0.25) and (max-zoom: 0.75) {
-  [data-radix-dialog-content] {
-    position: fixed !important;
-    left: 50% !important;
-    top: 50% !important;
-    transform: translate(-50%, -50%) !important;
-  }
-}
-
-/* Ensure visibility at all zoom levels */
-html[style*="zoom"] [data-radix-dialog-content],
-body[style*="zoom"] [data-radix-dialog-content] {
-  position: fixed !important;
-  left: 50% !important;
-  top: 50% !important;
-  transform: translate(-50%, -50%) !important;
-}
-
-/* Override any viewport scaling */
-@viewport {
-  zoom: 1.0;
-  width: device-width;
-}
-
-@-ms-viewport {
-  width: device-width;
-  zoom: 1.0;
-}
-
-/* Ensure dialog scrolling works properly */
-[data-radix-dialog-content] > div {
-  max-height: calc(85vh - 3rem);
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-/* Force modal to always be centered */
-[data-radix-dialog-content] {
-  position: fixed !important;
-  left: 50% !important;
-  top: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  z-index: 99999 !important;
+  z-index: 50 !important;
   max-height: 85vh !important;
   max-width: min(900px, 90vw) !important;
   width: 90vw !important;
   margin: 0 !important;
+  padding: 1.5rem !important;
   display: flex !important;
   flex-direction: column !important;
   align-items: stretch !important;
   justify-content: flex-start !important;
+}
+
+/* Mobile responsiveness */
+@media screen and (max-width: 768px) {
+  [data-radix-dialog-content] {
+    width: calc(100vw - 2rem) !important;
+    max-width: calc(100vw - 2rem) !important;
+    padding: 1rem !important;
+  }
+}
+
+/* Ensure content scrolling works properly */
+[data-radix-dialog-content] > div {
+  max-height: calc(85vh - 3rem);
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Fix for browsers with non-standard zoom */
@@ -111,36 +69,11 @@ body[style*="zoom"] [data-radix-dialog-content] {
 /* Ensure proper stacking context */
 .fixed[role="dialog"] {
   position: fixed !important;
-  z-index: 99999 !important;
+  z-index: 50 !important;
 }
 
-/* Additional centering rules for all scenarios */
+/* Box sizing for all elements */
 [data-radix-dialog-content],
 [data-radix-dialog-content] * {
   box-sizing: border-box !important;
-}
-
-/* Override any conflicting positioning */
-[data-radix-dialog-content] {
-  position: fixed !important;
-  left: 50% !important;
-  top: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  z-index: 99999 !important;
-  max-height: 85vh !important;
-  max-width: min(900px, 90vw) !important;
-  width: 90vw !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  display: flex !important;
-  flex-direction: column !important;
-  align-items: stretch !important;
-  justify-content: flex-start !important;
-}
-
-/* Ensure content doesn't overflow */
-[data-radix-dialog-content] > * {
-  max-height: 100% !important;
-  overflow-y: auto !important;
-  overflow-x: hidden !important;
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        "max-h-[90vh] overflow-y-auto", // Adicionado para garantir rolagem e altura máxima
+        "max-h-[85vh] overflow-y-auto", // Ajustado para 85vh para consistência
         className
       )}
       {...props}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import './components/ui/dialog-override.css'
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
Fix modal opening position by resolving CSS conflicts and importing override styles.

The modal was opening significantly below the desired position due to conflicting and overly specific CSS rules in `dialog-override.css`, excessive z-index values, and the fact that `dialog-override.css` was not being imported into the project. This PR simplifies the override CSS, adjusts the dialog component's max-height for consistency, and ensures the override CSS is correctly imported.

---
<a href="https://cursor.com/background-agent?bcId=bc-639cd656-99bf-4226-8666-83bd55f76f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-639cd656-99bf-4226-8666-83bd55f76f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

