### PR TITLE
Fix modal detail card opening position

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -100,13 +100,9 @@ All colors MUST be HSL.
   body {
     @apply bg-background text-foreground overflow-x-hidden;
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
-    zoom: 1;
-    transform: scale(1);
   }
 
   html {
-    zoom: 1;
-    transform: scale(1);
   }
 
   /* Garantir que não há zoom indesejado */
@@ -116,8 +112,6 @@ All colors MUST be HSL.
 
   /* Reset de zoom e escala */
   html, body {
-    zoom: 1 !important;
-    transform: scale(1) !important;
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
     text-size-adjust: 100%;


### PR DESCRIPTION
Remove `zoom` and `transform: scale(1)` from `html` and `body` to fix modal misalignment.

The `zoom` and `transform: scale(1)` properties applied globally to `html` and `body` were interfering with the `position: fixed` styling of Radix modals, causing them to render significantly below their intended centered position. Removing these properties allows the modal to center correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e7fab22-d6bb-42f2-8ec1-905f0864af04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e7fab22-d6bb-42f2-8ec1-905f0864af04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

