### PR TITLE
Add GitHub links to all portfolio projects

### DIFF
--- a/src/components/sections/services-section.tsx
+++ b/src/components/sections/services-section.tsx
@@ -37,6 +37,7 @@ const projects = [
     shortDescription: "Plataforma promocional com painel, segurança e operação em produção",
     image: fortaoPremiosImage,
     liveUrl: "https://xn--fortoprmios-c8a8g.com.br/",
+    githubUrl: "https://github.com/AlexandroGranja/fortao-premios",
     technologies: ["Next.js", "React", "Supabase", "Redis", "Tailwind CSS"],
     features: [
       "Área pública para campanhas e vendas",
@@ -659,12 +660,12 @@ export const ProjectsSection: React.FC = () => {
                                 <ExternalLink className="ml-2 h-4 w-4" />
                               </Button>
                             )}
-                            {!project.liveUrl && project.githubUrl && (
+                            {project.githubUrl && (
                               <Button size="sm" variant="outline" className="border-primary/35 hover:border-primary/55 hover:bg-primary/10" onClick={() => window.open(project.githubUrl, "_blank")}>
-                                Ver referência
+                                Ver no GitHub
                                 <Github className="ml-2 h-4 w-4" />
                               </Button>
-                    )}
+                            )}
                   </div>
                 </CardContent>
                       </div>


### PR DESCRIPTION
## Summary

- Adiciona `githubUrl` para o projeto **Fortão Prêmios** (`https://github.com/AlexandroGranja/fortao-premios`), que estava sem link do GitHub
- Corrige a lógica dos botões: agora o botão **"Ver no GitHub"** aparece em **todos** os projetos com `githubUrl`, e não só nos que não têm URL ao vivo
- Renomeia o botão de "Ver referência" para "Ver no GitHub" para maior clareza

## Projetos com links do GitHub

| Projeto | GitHub |
|---|---|
| Fortão Prêmios | ✅ adicionado |
| Burger House | ✅ já existia |
| Moraes Adesivos | ✅ já existia |
| Prosper Roteiros | ✅ já existia |
| Processador de XML | ✅ já existia |

https://claude.ai/code/session_01NxnjLT6s2qUwSN9k7p9VbB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnjLT6s2qUwSN9k7p9VbB)_